### PR TITLE
Remove comma in date with month literal, as it is ambigous to date/time separator

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1190,3 +1190,53 @@ fn test_year_before() {
     assert_eq!(date.month(), 10);
     assert_eq!(date.day(), 5);
 }
+
+#[test]
+fn test_month_literals_with_time_and_year() {
+    use chrono::Timelike;
+
+    let lexemes = vec![
+        Lexeme::February,
+        Lexeme::Num(16),
+        Lexeme::Num(2022),
+        Lexeme::Comma,
+        Lexeme::Num(5),
+        Lexeme::Colon,
+        Lexeme::Num(27),
+        Lexeme::PM,
+    ];
+    let (date, t) = DateTime::parse(lexemes.as_slice()).unwrap();
+    let date = date.to_chrono(Local::now().naive_local().time()).unwrap();
+
+    assert_eq!(t, 8);
+    assert_eq!(date.year(), 2022);
+    assert_eq!(date.month(), 2);
+    assert_eq!(date.day(), 16);
+    assert_eq!(date.hour(), 17);
+    assert_eq!(date.minute(), 27);
+}
+
+#[test]
+fn test_month_literals_with_time_and_no_year() {
+    use chrono::Timelike;
+
+    let lexemes = vec![
+        Lexeme::February,
+        Lexeme::Num(16),
+        Lexeme::Comma,
+        Lexeme::Num(5),
+        Lexeme::Colon,
+        Lexeme::Num(27),
+        Lexeme::PM,
+    ];
+    let (date, t) = DateTime::parse(lexemes.as_slice()).unwrap();
+    let date = date.to_chrono(Local::now().naive_local().time()).unwrap();
+    let current_year = Local::now().naive_local().year();
+
+    assert_eq!(t, 7);
+    assert_eq!(date.year(), current_year);
+    assert_eq!(date.month(), 2);
+    assert_eq!(date.day(), 16);
+    assert_eq!(date.hour(), 17);
+    assert_eq!(date.minute(), 27);
+}

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -159,10 +159,6 @@ impl Date {
             let (day, t) = Num::parse(&l[tokens..])?;
             tokens += t;
 
-            if l.get(tokens) == Some(&Lexeme::Comma) {
-                tokens += 1;
-            }
-
             if let Some((year, t)) = Num::parse(&l[tokens..]) {
                 tokens += t;
                 return Some((Self::MonthDayYear(month, day, year), tokens));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,6 @@
 //!          | <num> / <num> / <num>
 //!          | <num> - <num> - <num>
 //!          | <month> <num> <num>
-//!          | <month> <num> , <num>
 //!          | <relative_specifier> <unit>
 //!          | <relative_specifier> <weekday>
 //!          | <weekday>


### PR DESCRIPTION
When playing around with this library I noticed, that there is an ambiguity in parsing when using dates with month literal and time. I tired entering a date without year but with time:

```
jan 3, 18:00
```

This is interpreted by the library as `0018-01-03`. Although, I would have expected it to interpret `2023-01-03T18:00` with the year taken from the current year. The problem is that a date with month literal in the beginning can include a comma

```
<date> ::= ...
         | <month> <num> , <num>
         | ...
```

and the datetime it self containes a comma as separator between date and time

```
<datetime> ::= ...
             | <date> , <time>
             | ....
```

I removed this ambiguity by removing the comma separator for the date itself. As I felt like this is not needed.

I provided this pull request as suggestion because it works best for me this way, but it is a breaking change if someone is using this. Maybe there is a better way to solve this without breaking something. 