### PR TITLE
Add DMY with dot separator date format

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1190,3 +1190,102 @@ fn test_year_before() {
     assert_eq!(date.month(), 10);
     assert_eq!(date.day(), 5);
 }
+
+#[test]
+fn test_slash_separated_date() {
+    let lexemes = vec![
+        Lexeme::Num(5),
+        Lexeme::Slash,
+        Lexeme::Num(12),
+        Lexeme::Slash,
+        Lexeme::Num(2023),
+    ];
+    let (date, t) = DateTime::parse(lexemes.as_slice()).unwrap();
+    let date = date.to_chrono(Local::now().naive_local().time()).unwrap();
+
+    assert_eq!(t, 5);
+    assert_eq!(date.year(), 2023);
+    assert_eq!(date.month(), 5);
+    assert_eq!(date.day(), 12);
+}
+
+#[test]
+fn test_slash_separated_invalid_month() {
+    let lexemes = vec![
+        Lexeme::Num(13),
+        Lexeme::Slash,
+        Lexeme::Num(12),
+        Lexeme::Slash,
+        Lexeme::Num(2023),
+    ];
+    let (date, _) = DateTime::parse(lexemes.as_slice()).unwrap();
+    let date = date.to_chrono(Local::now().naive_local().time());
+
+    assert!(date.is_err());
+}
+
+#[test]
+fn test_dash_separated_date() {
+    let lexemes = vec![
+        Lexeme::Num(5),
+        Lexeme::Dash,
+        Lexeme::Num(12),
+        Lexeme::Dash,
+        Lexeme::Num(2023),
+    ];
+    let (date, t) = DateTime::parse(lexemes.as_slice()).unwrap();
+    let date = date.to_chrono(Local::now().naive_local().time()).unwrap();
+
+    assert_eq!(t, 5);
+    assert_eq!(date.year(), 2023);
+    assert_eq!(date.month(), 5);
+    assert_eq!(date.day(), 12);
+}
+
+#[test]
+fn test_dash_separated_invalid_month() {
+    let lexemes = vec![
+        Lexeme::Num(13),
+        Lexeme::Dash,
+        Lexeme::Num(12),
+        Lexeme::Dash,
+        Lexeme::Num(2023),
+    ];
+    let (date, _) = DateTime::parse(lexemes.as_slice()).unwrap();
+    let date = date.to_chrono(Local::now().naive_local().time());
+
+    assert!(date.is_err());
+}
+
+#[test]
+fn test_dot_separated_date() {
+    let lexemes = vec![
+        Lexeme::Num(19),
+        Lexeme::Dot,
+        Lexeme::Num(12),
+        Lexeme::Dot,
+        Lexeme::Num(2023),
+    ];
+    let (date, t) = DateTime::parse(lexemes.as_slice()).unwrap();
+    let date = date.to_chrono(Local::now().naive_local().time()).unwrap();
+
+    assert_eq!(t, 5);
+    assert_eq!(date.year(), 2023);
+    assert_eq!(date.month(), 12);
+    assert_eq!(date.day(), 19);
+}
+
+#[test]
+fn test_dot_separated_date_invalid_month() {
+    let lexemes = vec![
+        Lexeme::Num(19),
+        Lexeme::Dot,
+        Lexeme::Num(13),
+        Lexeme::Dot,
+        Lexeme::Num(2023),
+    ];
+    let (date, _) = DateTime::parse(lexemes.as_slice()).unwrap();
+    let date = date.to_chrono(Local::now().naive_local().time());
+
+    assert!(date.is_err());
+}

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -182,24 +182,37 @@ impl Date {
         } else if let Some((weekday, t)) = Weekday::parse(&l[tokens..]) {
             tokens += t;
             return Some((Self::Weekday(weekday), tokens));
-        } else if let Some((month, t)) = Num::parse(&l[tokens..]) {
+        } else if let Some((num1, t)) = Num::parse(&l[tokens..]) {
             tokens += t;
             if let Some(delim) = l.get(tokens) {
-                if delim == &Lexeme::Slash || delim == &Lexeme::Dash {
+                if delim == &Lexeme::Slash || delim == &Lexeme::Dash || delim == &Lexeme::Dot {
                     // Consume slash or dash
                     tokens += 1;
 
-                    if let Some((day, t)) = Num::parse(&l[tokens..]) {
+                    if let Some((num2, t)) = Num::parse(&l[tokens..]) {
                         tokens += t;
                         if l.get(tokens)? == delim {
                             // Consume slash or dash
                             tokens += 1;
 
-                            let (year, t) = Num::parse(&l[tokens..])?;
+                            let (num3, t) = Num::parse(&l[tokens..])?;
                             tokens += t;
-                            return Some((Self::MonthNumDayYear(month, day, year), tokens));
+
+                            // If delim is dot use DMY, otherwise MDY
+                            if delim == &Lexeme::Dot {
+                                return Some((Self::MonthNumDayYear(num2, num1, num3), tokens));
+                            }
+                            else {
+                                return Some((Self::MonthNumDayYear(num1, num2, num3), tokens));
+                            }
                         } else {
-                            return Some((Self::MonthNumDay(month, day), tokens));
+                            // If delim is dot use DMY, otherwise MDY
+                            if delim == &Lexeme::Dot {
+                                return Some((Self::MonthNumDay(num2, num1), tokens));
+                            }
+                            else {
+                                return Some((Self::MonthNumDay(num1, num2), tokens));
+                            }
                         }
                     }
                 }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -252,6 +252,11 @@ impl Lexeme {
                     push_lexeme(&mut stack, &mut lexemes)?;
                     lexemes.push(Lexeme::Dash);
                 }
+                // Dot separates lexemes, push stack and add dash
+                '.' => {
+                    push_lexeme(&mut stack, &mut lexemes)?;
+                    lexemes.push(Lexeme::Dot);
+                }
                 // Else just add the character to our stack
                 _ => stack.push(c),
             }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -120,6 +120,7 @@ pub enum Lexeme {
     And,
     Comma,
     Colon,
+    Dot,
     After,
     Num(u32),
     This,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,7 @@
 //!          | yesterday
 //!          | <num> / <num> / <num>
 //!          | <num> - <num> - <num>
+//!          | <num> . <num> . <num>
 //!          | <month> <num> <num>
 //!          | <month> <num> , <num>
 //!          | <relative_specifier> <unit>


### PR DESCRIPTION
Add date format with dot separator. This date format is used in the EU and especially in German speaking countries. In contrast to the existing date formats which are month first, this one is day first. Like this:

```
25.12.2012
```

in contrast to

```
12/25/2023
```

I changed the parsing that now dates separated with dot are interpreted as day first and the others (dash, slash) are interpreted as month first.