### PR TITLE
fix: support date from <relative_specifier> <unit>

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -124,6 +124,7 @@ pub enum Date {
     MonthDayYear(Month, u32, u32),
     MonthNumDay(u32, u32),
     MonthDay(Month, u32),
+    UnitRelative(RelativeSpecifier, Unit),
     Relative(RelativeSpecifier, Weekday),
     Weekday(Weekday),
     Today,
@@ -174,6 +175,11 @@ impl Date {
             if let Some((weekday, t)) = Weekday::parse(&l[tokens..]) {
                 tokens += t;
                 return Some((Self::Relative(relspec, weekday), tokens));
+            }
+
+            if let Some((unit, t)) = Unit::parse(&l[tokens..]) {
+                tokens += t;
+                return Some((Self::UnitRelative(relspec, unit), tokens));
             }
         } else if let Some((weekday, t)) = Weekday::parse(&l[tokens..]) {
             tokens += t;
@@ -280,6 +286,19 @@ impl Date {
 
                 while date.weekday() != weekday {
                     date += ChronoDuration::days(1);
+                }
+
+                date
+            }
+            Date::UnitRelative(relspec, unit) => {
+                let today = Local::now().naive_local();
+                let mut date = today.date();
+                if relspec == &RelativeSpecifier::Next {
+                    date = Duration::Specific(1, unit.to_owned()).after(today).date();
+                }
+
+                if relspec == &RelativeSpecifier::Last {
+                    date = Duration::Specific(1, unit.to_owned()).before(today).date();
                 }
 
                 date
@@ -611,7 +630,7 @@ impl Duration {
     }
 }
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
 pub enum Unit {
     Day,
     Week,
@@ -1196,6 +1215,92 @@ fn test_year_before() {
     assert_eq!(date.year(), today.year() - 1);
     assert_eq!(date.month(), 10);
     assert_eq!(date.day(), 5);
+}
+
+#[test]
+fn test_next_week() {
+    let l = vec![Lexeme::Next, Lexeme::Week];
+
+    let today = Local::now().naive_local();
+    let (date, _) = DateTime::parse(l.as_slice()).unwrap();
+    let date = date.to_chrono(today.time()).unwrap();
+
+    assert_eq!(date, today + ChronoDuration::weeks(1));
+}
+
+#[test]
+fn test_next_month() {
+    let l = vec![Lexeme::Next, Lexeme::Month];
+
+    let today = Local::now().naive_local();
+    let (date, _) = DateTime::parse(l.as_slice()).unwrap();
+    let date = date.to_chrono(today.time()).unwrap();
+
+    assert_eq!(
+        date,
+        today
+            .checked_add_months(chrono::Months::new(1))
+            .expect("Adding one month to current date shouldn't be the end of time.")
+    );
+}
+
+#[test]
+fn test_next_year() {
+    let l = vec![Lexeme::Next, Lexeme::Year];
+
+    let today = Local::now().naive_local();
+    let (date, _) = DateTime::parse(l.as_slice()).unwrap();
+    let date = date.to_chrono(today.time()).unwrap();
+
+    assert_eq!(
+        date,
+        today
+            .with_year(today.year() + 1)
+            .expect("Adding one year to current date shouldn't be the end of time.")
+    );
+}
+
+#[test]
+fn test_last_week() {
+    let l = vec![Lexeme::Last, Lexeme::Week];
+
+    let today = Local::now().naive_local();
+    let (date, _) = DateTime::parse(l.as_slice()).unwrap();
+    let date = date.to_chrono(today.time()).unwrap();
+
+    assert_eq!(date, today - ChronoDuration::weeks(1));
+}
+
+#[test]
+fn test_last_month() {
+    let l = vec![Lexeme::Last, Lexeme::Month];
+
+    let today = Local::now().naive_local();
+    let (date, _) = DateTime::parse(l.as_slice()).unwrap();
+    let date = date.to_chrono(today.time()).unwrap();
+
+    assert_eq!(
+        date,
+        today
+            .checked_sub_months(chrono::Months::new(1))
+            .expect("Subtracting one month to current date shouldn't be the end of time.")
+    );
+}
+
+#[test]
+fn test_last_year() {
+    let l = vec![Lexeme::Last, Lexeme::Year];
+
+    let today = Local::now().naive_local();
+    let (date, _) = DateTime::parse(l.as_slice()).unwrap();
+    let date = date.to_chrono(today.time()).unwrap();
+
+    assert_eq!(
+        date,
+        today
+            .with_year(today.year() - 1)
+            .expect("Subtracting one year to current date shouldn't be the end of time.")
+    );
 }
 
 #[test]


### PR DESCRIPTION
Add support for `date ::= <relative_specifier> <unit>` with accompanying tests.

Fix #6