### PR TITLE
Make next and last week use ISO weeks

### DIFF
--- a/fuzzydate/src/ast.rs
+++ b/fuzzydate/src/ast.rs
@@ -368,6 +368,8 @@ impl Date {
                 let this_week = today.iso_week();
 
                 match spec {
+                    // iterate to the beginning or end of the correct week, then iterate through
+                    // the week to the correct day
                     RelativeSpecifier::Next => {
                         while today.iso_week() == this_week {
                             today += ChronoDuration::days(1);


### PR DESCRIPTION
Fixes #17 

Changes specifiers for weeks relative to the current week (next, this, last) to use ISO weeks to determine which week the specified day belongs to. This may be slightly confusing for folks who expect weeks to begin on Sunday, but is easy to explain.