### PR TITLE
Add year, moth, day as a supported triple format and num, month as a supported double format

### DIFF
--- a/fuzzydate/src/ast.rs
+++ b/fuzzydate/src/ast.rs
@@ -158,7 +158,6 @@ pub enum Date {
     MonthDayYear(Month, u32, u32),
     MonthNumDay(u32, u32),
     MonthDay(Month, u32),
-    MonthYear(Month, u32),
     Today,
     Tomorrow,
     Yesterday,
@@ -215,9 +214,6 @@ impl Date {
                 return Some((Self::MonthDayYear(month, num, year), tokens));
             }
 
-            if num > 1000 {
-                return Some((Self::MonthYear(month, num), tokens));
-            }
             return Some((Self::MonthDay(month, num), tokens));
         }
 
@@ -356,12 +352,6 @@ impl Date {
                 let month = *month as u32;
                 ChronoDate::from_ymd_opt(today.year(), month, *day).ok_or(
                     crate::Error::InvalidDate(format!("Invalid month-day: {month}-{day}")),
-                )?
-            }
-            Self::MonthYear(month, year) => {
-                let month = *month as u32;
-                ChronoDate::from_ymd_opt(*year as i32, month, today.day()).ok_or(
-                    crate::Error::InvalidDate(format!("Invalid month-year: {month}-{year}")),
                 )?
             }
             Self::MonthDayYear(month, day, year) | Self::DayMonthYear(day, month, year) => {

--- a/fuzzydate/src/lib.rs
+++ b/fuzzydate/src/lib.rs
@@ -51,9 +51,9 @@
 //!               | <num> . <num> . <num>  ; D[D] . M[M] . Y[Y][YY]
 //!               | <month> <num> <num>
 //!               | <num> <month> <num>
-//!               | <month> <num>     ; month year if num > 1000, otherwise month day
-//!               | <num> <month>     ; day month
-//!               | <duration> ago              ; duration must be for a whole number of days
+//!               | <month> <num>
+//!               | <num> <month>
+//!               | <duration> ago         ; duration must be for a whole number of days
 //!               | <duration> after <date>
 //!               | <duration> from <date>
 //!               | <duration> before <date>


### PR DESCRIPTION
#20 Raised that YYYY-MM-DD and DD <month name> are not supported. Add support for year, month, day triples and additional combinations of month names and numbers.