### PR TITLE
update version number in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Put this in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-fuzzydate = "0.3"
+fuzzydate = "0.4"
 ```
 
 See the [fuzzydate crate README](fuzzydate/README.md) for more information.

--- a/fuzzydate-cli/Cargo.toml
+++ b/fuzzydate-cli/Cargo.toml
@@ -11,7 +11,7 @@ repository.workspace = true
 
 [dependencies]
 # This is patched in the workspace root to use the local path for development
-fuzzydate = "0.3.1"
+fuzzydate = "0.4"
 clap = {version = "4.5", features=["derive"]}
 anyhow = "1.0"
 chrono-tz = "0.10.4"

--- a/fuzzydate/README.md
+++ b/fuzzydate/README.md
@@ -21,7 +21,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-fuzzydate = "0.3"
+fuzzydate = "0.4"
 ```
 
 ## Examples


### PR DESCRIPTION
Update version numbers in documentation and fuzzydate-cli Cargo.toml to reference the upcoming 0.4 release.